### PR TITLE
Fix logic in tagging section

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@ else
     proxy_string_win = ""
 end
 # Next we determine the server tag string
-if node[:cloudpassage][:proxy_url] != "" then
+if node[:cloudpassage][:tag] != "" then
     tag_string_lin = "--tag=#{node[:cloudpassage][:tag]}"
     tag_string_win = "/tag=#{node[:cloudpassage][:tag]}"
 else


### PR DESCRIPTION
Changed the logic to check the tag node variable instead of proxy_url.
I suspect this was caused by a merge issue.
